### PR TITLE
Prevent deletePixel splicing of index -1 as a cause of ghost pixels

### DIFF
--- a/index.html
+++ b/index.html
@@ -7000,7 +7000,7 @@
         }
         function deletePixel(x,y) {
             // remove pixelMap[x][y] from currentPixels
-            currentPixels.splice(currentPixels.indexOf(pixelMap[x][y]),1);
+            if(currentPixels.indexOf(pixelMap[x][y]) !== -1) { currentPixels.splice(currentPixels.indexOf(pixelMap[x][y]),1) };
             if (pixelMap[x][y]) {pixelMap[x][y].del = true;}
             delete pixelMap[x][y];
             /*for (var i = 0; i < currentPixels.length; i++) {


### PR DESCRIPTION
When this happens, pixels are "deleted" starting from the newest pixel created and become ghost pixels, present in pixelMap but not currentPixels. In generated worlds, this presents as the pixels disappearing upwards and leftwards from the bottom right)

![Manually created ghost pixels](https://user-images.githubusercontent.com/68935009/207400531-b788fe53-f367-4a8b-aaf0-e07fcae2d6ac.png)

![Console snippets showing one of the ghost pixels' absence from currentPixels versus a normal pixel next to it](https://user-images.githubusercontent.com/68935009/207400767-63167e66-8ecf-440d-b9fa-53800682b0d7.png)