### PR TITLE
Adds desc duo

### DIFF
--- a/mods/descriptions.js
+++ b/mods/descriptions.js
@@ -1,0 +1,12 @@
+console.log("descriptions.js: Loading vanilla descriptions...");
+fetch("https://sandboxels-mods.mollthecoder.repl.co/descriptions/vanilla.json")
+  .then(res=>{
+    res.json().then(json=>{
+    for(const element in json) {
+      // If the element doesn't exist (for example, nocancer2.js) then don't try to change it.
+      if(!elements.hasOwnProperty(element)) continue;
+      elements[element].desc = json[element];
+    }
+    console.log("descriptions.js: Loaded vanilla descriptions!");
+  });
+});

--- a/mods/tooltip.js
+++ b/mods/tooltip.js
@@ -1,0 +1,21 @@
+const defaultTooltip = "---";
+let tooltipEle;
+window.addEventListener("load", ()=>{
+  tooltipEle = document.createElement("p");
+  tooltipEle.innerHTML = defaultTooltip;
+  document.getElementById("extraInfo").children[1].appendChild(tooltipEle);
+  let buttons = document.getElementsByClassName("elementButton");
+  [...buttons].forEach(button=>{
+    let ele = button.getAttribute("element");
+    button.addEventListener("mouseenter", e=>{
+      if(elements.hasOwnProperty(ele)) {
+        if(elements[ele].hasOwnProperty("desc")) {
+          tooltipEle.innerHTML = elements[ele].desc;
+        }
+      }
+    });
+    button.addEventListener("mouseleave", e=>{
+      tooltipEle.innerHTML = defaultTooltip;
+    });
+  });
+});


### PR DESCRIPTION
I'm calling this set of mods the desc duo.
Anyways, it adds two mods:
- descriptions.js (the main meat of the duo)
    It adds descriptions to most sandboxels elements. I skipped the states tab because there's so many. I'll start adding these in future updates.
- tooltip.js 
    It adds a tooltip at the bottom of the screen that shows the description of the currently hovered button element. It has a known issue of not registering newly discovered elements. This will be fixed in the next update.