### PR TITLE
Added melt-porcelain mod and Duncanium mod.

### DIFF
--- a/mods/Duncanium.js
+++ b/mods/Duncanium.js
@@ -1,0 +1,14 @@
+elements.duncanium = {
+  color: ["#ff0000","#f44336","#990000","#ea9999","#f4cccc"],
+  behavior: behaviors.WALL,
+  category: "solids",
+  state: "solid",
+  density: 99999,
+  burn: 0,
+  hardness: 1,
+  breakInto: "duncanium",
+  reactions: {
+    "water": { elem1: "duncanium", elem2: "duncanium" },
+    "fire": { elem1: "duncanium", elem2: null},
+  }
+};

--- a/mods/melt-porcelain.js
+++ b/mods/melt-porcelain.js
@@ -1,6 +1,6 @@
 //Porcelain turns into molten_porcelain at 3275 degrees.
 
-elements.molten_porcelain{
+elements.molten_porcelain = {
   color: ["#ff0000", "#ffa500", "#ffd700"],          // Set color to red, orange, and gold.
   category: "states",
   behavior: behaviors.MOLTEN,                        // Set state to MOLTEN.

--- a/mods/melt-porcelain.js
+++ b/mods/melt-porcelain.js
@@ -1,0 +1,12 @@
+//Porcelain turns into molten_porcelain at 3275 degrees.
+
+elements.molten_porcelain{
+  color: ["#ff0000", "#ffa500", "#ffd700"],          // Set color to red, orange, and gold.
+  category: "states",
+  behavior: behaviors.MOLTEN,                        // Set state to MOLTEN.
+  tempLow: 3274,                                     // At 3274 Celsius, molten_porcelain turns back into...
+  stateLow: "porcelain"                              // ... porcelain!
+}
+
+elements.porcelain.tempHigh = 3275;                  // At 3275 Celsius, porcelain melts into...
+elements.porcelain.stateHigh = "molten_porcelain";   // molten_porcelain.


### PR DESCRIPTION
melt-porcelain.js:
Porcelain turns into molten porcelain at 3275 Celsius, and molten porcelain turns back into porcelain at 3274 Celsius.
(Solution to issue: https://github.com/R74nCom/sandboxels/issues/130#issue-1890741739 )

Duncanium.js:
Duncanium is an indestructible element that clones through water.