### PR TITLE
lye.js - A mod adding lye

### DIFF
--- a/mods/lye.js
+++ b/mods/lye.js
@@ -1,0 +1,34 @@
+/*
+MIT License
+
+Copyright (c) 2024 BatteRaquette58 (a.k.a BatteRaquette581)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+elements.lye = {
+    color: "#e5cccc",
+    behavior: behaviors.POWDER,
+    category: "powders",
+    state: "solid",
+    tempHigh: 1388,
+    stateHigh: "caustic_potash",
+}
+
+elements.water.reactions.ash.elem2 = "lye"


### PR DESCRIPTION
A simple mod which adds lye (also known as sodium hydroxide and caustic soda), with its reactions (modifies water's reaction with ash to make ash turn into lye), and lye becoming caustic potash at its burning point (1388°C).