### PR TITLE
no_scroll.js

### DIFF
--- a/mods/no_scroll.js
+++ b/mods/no_scroll.js
@@ -1,0 +1,5 @@
+// For macOS magic mouse users.
+
+wheelHandle = function(e) {
+    e.preventDefault();
+};


### PR DESCRIPTION
A simple patch for macOS Magic Mouse users. Draggng the cursor around sometimes results in unwanted scrolling, resulting in a frustrating experience, since the brush size keeps adjusting.