### PR TITLE
Emergency fix #2 for Neutronium Mod.js

### DIFF
--- a/mods/Neutronium Mod.js
+++ b/mods/Neutronium Mod.js
@@ -1110,6 +1110,7 @@ state: "solid",
 behavior: behaviors.RADIOACTIVE_POWDER,
 tempHigh: 1132,
 stateHigh: "molten_uranium233",
+forceAutoGen: true,
 density: 19,
 };
 elements.uranium235 = {
@@ -1123,6 +1124,7 @@ behavior: [
 "XX|XX|XX",
 ],
 tempHigh: 1132.2,
+forceAutoGen: true,
 stateHigh: "molten_uranium235",
 density: 19.1,
 };
@@ -1138,6 +1140,7 @@ behavior: [
 ],
 tempHigh: 1131,
 stateHigh: "molten_uranium238",
+forceAutoGen: true,
 density: 20,
 };
 /* Removed:


### PR DESCRIPTION
This bug can easily freeze the game, so I think it really has to be addressed.

Per the commit description:
> Attempting to melt the uranium isotopes now causes an undefined-element error in pixelTempCheck and freezes the game. For some reason, the molten states are no longer being generated by default, and so forceAutoGen is needed to fix this.